### PR TITLE
Move global context entries to dedicated libraries

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,8 +26,8 @@
   "peerDependencies": {
     "@frontmeans/input-aspects": "^4.4.0",
     "@proc7ts/fun-events": "^10.5.0",
-    "@wesib/generic": "^2.0.0-dev.0",
-    "@wesib/wesib": "^2.0.0-dev.0"
+    "@wesib/generic": "^2.0.0",
+    "@wesib/wesib": "^2.0.0"
   },
   "dependencies": {
     "@frontmeans/dom-events": "^1.2.0",
@@ -51,8 +51,8 @@
     "@types/jsdom": "^16.2.13",
     "@typescript-eslint/eslint-plugin": "^4.28.2",
     "@typescript-eslint/parser": "^4.28.2",
-    "@wesib/generic": "^2.0.0-dev.0",
-    "@wesib/wesib": "^2.0.0-dev.0",
+    "@wesib/generic": "^2.0.0",
+    "@wesib/wesib": "^2.0.0",
     "eslint": "^7.30.0",
     "eslint-plugin-jest": "^24.3.6",
     "gh-pages": "^3.2.3",

--- a/package.json
+++ b/package.json
@@ -31,8 +31,8 @@
   },
   "dependencies": {
     "@frontmeans/dom-events": "^1.2.0",
-    "@frontmeans/namespace-aliaser": "^2.6.0-dev.0",
-    "@frontmeans/render-scheduler": "^1.8.0-dev.0",
+    "@frontmeans/namespace-aliaser": "^2.6.0",
+    "@frontmeans/render-scheduler": "^1.8.0",
     "@proc7ts/amend": "^1.0.0",
     "@proc7ts/context-values": "^7.0.0-dev.13",
     "@proc7ts/primitives": "^3.0.2",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   },
   "dependencies": {
     "@frontmeans/dom-events": "^1.2.0",
-    "@frontmeans/namespace-aliaser": "^2.6.0",
+    "@frontmeans/namespace-aliaser": "^2.6.1",
     "@frontmeans/render-scheduler": "^1.8.0",
     "@proc7ts/amend": "^1.0.0",
     "@proc7ts/context-values": "^7.0.0-dev.13",

--- a/package.json
+++ b/package.json
@@ -31,10 +31,10 @@
   },
   "dependencies": {
     "@frontmeans/dom-events": "^1.2.0",
-    "@frontmeans/namespace-aliaser": "^2.6.1",
-    "@frontmeans/render-scheduler": "^1.8.0",
+    "@frontmeans/namespace-aliaser": "^2.6.2",
+    "@frontmeans/render-scheduler": "^1.8.1",
     "@proc7ts/amend": "^1.0.0",
-    "@proc7ts/context-values": "^7.0.0-dev.13",
+    "@proc7ts/context-values": "^7.0.0",
     "@proc7ts/primitives": "^3.0.2",
     "@proc7ts/push-iterator": "^2.6.0",
     "@proc7ts/supply": "^1.2.3"
@@ -43,7 +43,7 @@
     "@frontmeans/input-aspects": "^4.3.0",
     "@frontmeans/render-scheduler": "^1.5.0",
     "@jest/globals": "^27.0.6",
-    "@proc7ts/context-builder": "^7.0.0-dev.13",
+    "@proc7ts/context-builder": "^7.0.0",
     "@proc7ts/fun-events": "^10.5.0",
     "@rollup/plugin-node-resolve": "^13.0.0",
     "@run-z/eslint-config": "^1.3.0",

--- a/package.json
+++ b/package.json
@@ -31,8 +31,8 @@
   },
   "dependencies": {
     "@frontmeans/dom-events": "^1.2.0",
-    "@frontmeans/namespace-aliaser": "^2.5.0",
-    "@frontmeans/render-scheduler": "^1.7.0",
+    "@frontmeans/namespace-aliaser": "^2.6.0-dev.0",
+    "@frontmeans/render-scheduler": "^1.8.0-dev.0",
     "@proc7ts/amend": "^1.0.0",
     "@proc7ts/context-values": "^7.0.0-dev.13",
     "@proc7ts/primitives": "^3.0.2",

--- a/src/default.preset.impl.ts
+++ b/src/default.preset.impl.ts
@@ -6,7 +6,8 @@ import {
   InRenderScheduler,
   knownInAspect,
 } from '@frontmeans/input-aspects';
-import { ComponentContext, ComponentRenderScheduler, DefaultNamespaceAliaser } from '@wesib/wesib';
+import { NamespaceAliaser } from '@frontmeans/namespace-aliaser';
+import { ComponentContext, ComponentRenderScheduler } from '@wesib/wesib';
 import { Field } from './field';
 import { Form } from './form';
 import { FormPreset } from './form-preset';
@@ -33,7 +34,7 @@ function DefaultFormPreset$setup<TValue, TSharer extends object>(
     builder: InBuilder<InControl<TValue>>,
 ): void {
 
-  const nsAliaser = sharer.get(DefaultNamespaceAliaser);
+  const nsAliaser = sharer.get(NamespaceAliaser);
   const renderScheduler = sharer.get(ComponentRenderScheduler);
 
   builder

--- a/src/form-preset.spec.ts
+++ b/src/form-preset.spec.ts
@@ -10,17 +10,11 @@ import {
   InRenderScheduler,
   inValue,
 } from '@frontmeans/input-aspects';
+import { NamespaceAliaser } from '@frontmeans/namespace-aliaser';
 import { newManualRenderScheduler, RenderScheduler } from '@frontmeans/render-scheduler';
 import { beforeEach, describe, expect, it, jest } from '@jest/globals';
 import { cxConstAsset } from '@proc7ts/context-builder';
-import {
-  Component,
-  ComponentContext,
-  ComponentRenderScheduler,
-  ComponentSlot,
-  DefaultNamespaceAliaser,
-  DefinitionContext,
-} from '@wesib/wesib';
+import { Component, ComponentContext, ComponentRenderScheduler, ComponentSlot, DefinitionContext } from '@wesib/wesib';
 import { MockElement, testElement } from '@wesib/wesib/testing';
 import { Field } from './field';
 import { FieldShare } from './field.share';
@@ -232,8 +226,8 @@ describe('FormPreset', () => {
 
         expect(mockRenderScheduler).toHaveBeenLastCalledWith({ ...opts });
       });
-      it('sets `InNamespaceAliaser` to `DefaultNamespaceAliaser`', () => {
-        expect(form.control!.aspect(InNamespaceAliaser)).toBe(context.get(DefaultNamespaceAliaser));
+      it('sets `InNamespaceAliaser` to `NamespaceAliaser`', () => {
+        expect(form.control!.aspect(InNamespaceAliaser)).toBe(context.get(NamespaceAliaser));
       });
     });
 
@@ -247,8 +241,8 @@ describe('FormPreset', () => {
 
         expect(mockRenderScheduler).toHaveBeenLastCalledWith({ ...opts });
       });
-      it('sets `InNamespaceAliaser` to `DefaultNamespaceAliaser`', () => {
-        expect(form.element!.aspect(InNamespaceAliaser)).toBe(context.get(DefaultNamespaceAliaser));
+      it('sets `InNamespaceAliaser` to `NamespaceAliaser`', () => {
+        expect(form.element!.aspect(InNamespaceAliaser)).toBe(context.get(NamespaceAliaser));
       });
     });
 
@@ -262,8 +256,8 @@ describe('FormPreset', () => {
 
         expect(mockRenderScheduler).toHaveBeenLastCalledWith({ ...opts });
       });
-      it('sets `InNamespaceAliaser` to `DefaultNamespaceAliaser`', () => {
-        expect(field.control!.aspect(InNamespaceAliaser)).toBe(context.get(DefaultNamespaceAliaser));
+      it('sets `InNamespaceAliaser` to `NamespaceAliaser`', () => {
+        expect(field.control!.aspect(InNamespaceAliaser)).toBe(context.get(NamespaceAliaser));
       });
     });
 

--- a/src/form-preset.ts
+++ b/src/form-preset.ts
@@ -49,8 +49,8 @@ export interface FormPreset {
  *
  * As a bare minimum it attaches the following aspects to controls:
  *
- * - `InRenderScheduler` set to `ElementRenderScheduler`,
- * - `InNamespaceAliaser` set to `DefaultNamespaceAliaser.
+ * - `InRenderScheduler` set to `ComponentRenderScheduler`,
+ * - `InNamespaceAliaser` set to `NamespaceAliaser.
  */
 export const FormPreset: FormPreset.Static = {
 


### PR DESCRIPTION
- Utilize global `NamespaceAliaser`
- Utilize `DocumentRenderKit` defined in `@frontmeans/drek`
